### PR TITLE
feat: ensure all resourceVersions referenced by events are sent downstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ genotelcontribcol: $(BUILDER)
 otelcontribcolbuilder: $(BUILDER)
 	mkdir -p ./dist
 	$(BUILDER) --skip-compilation --config ./builder/lumigo-builder-config.yaml
-	cd ./dist/ && GOOS=$(go_os) GOARCH=$(go_arch) CGO_ENABLED=0 $(GOCMD) build -trimpath -o ./otelcontribcol_$(go_os)_$(go_arch)$(EXTENSION) \
+	cd ./dist/ && GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 $(GOCMD) build -trimpath -o ./otelcontribcol_$(GOOS)_$(GOARCH)$(EXTENSION) \
 		$(BUILD_INFO) -tags $(GO_BUILD_TAGS) .
 
 # Build the Collector executable.

--- a/builder/lumigo-builder-config.yaml
+++ b/builder/lumigo-builder-config.yaml
@@ -10,6 +10,7 @@ exporters:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter v0.71.0"
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.71.0
   - gomod: "go.opentelemetry.io/collector/exporter/otlphttpexporter v0.71.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.71.0"
 
 extensions:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.71.0"
@@ -18,12 +19,12 @@ extensions:
 
 receivers:
   - gomod: "go.opentelemetry.io/collector/receiver/otlpreceiver v0.71.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.71.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.71.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.71.0"
 
 processors:
   - gomod: "go.opentelemetry.io/collector/processor/batchprocessor v0.71.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.71.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.71.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.71.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.71.0"
@@ -33,3 +34,4 @@ processors:
 replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/extension/lumigoauthextension v0.71.0 => ../extension/lumigoauthextension
   - github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionbykeyprocessor v0.71.0 => ../processor/redactionbykeyprocessor
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.71.0 => ../receiver/k8sobjectsreceiver

--- a/receiver/k8sobjectsreceiver/go.mod
+++ b/receiver/k8sobjectsreceiver/go.mod
@@ -3,6 +3,9 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobj
 go 1.18
 
 require (
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.23.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.71.0
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.71.0
@@ -12,6 +15,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.0.0-rc5
 	go.opentelemetry.io/collector/semconv v0.71.0
 	go.uber.org/zap v1.24.0
+	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 )
@@ -29,6 +33,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/hpcloud/tail v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -62,10 +67,11 @@ require (
 	google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 // indirect
 	google.golang.org/grpc v1.52.3 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect

--- a/receiver/k8sobjectsreceiver/go.sum
+++ b/receiver/k8sobjectsreceiver/go.sum
@@ -225,6 +225,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -238,6 +239,7 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -332,6 +334,7 @@ github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
+github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/openshift/api v0.0.0-20210521075222-e273a339932a h1:aBPwLqCg66SbQd+HrjB1GhgTfPtqSY4aeB022tEYmE0=
 github.com/openshift/api v0.0.0-20210521075222-e273a339932a/go.mod h1:izBmoXbUu3z5kUa4FjZhvekTsyzIWiOoaIgJiZBBMQs=
 github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
@@ -730,10 +733,12 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -16,17 +16,42 @@ package k8sobjectsreceiver // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/hashicorp/golang-lru/simplelru"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
+
+var (
+	podv1         = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	eventv1       = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Event"}
+	daemonsetv1   = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}
+	deploymentv1  = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	replicasetv1  = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+	statefulsetv1 = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
+	cronjobv1     = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}
+	jobv1         = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+)
+
+var cache, _ = simplelru.NewLRU(1000, func(key interface{}, value interface{}) {
+	// Callback for key eviction. Anything to do?
+})
 
 type k8sobjectsreceiver struct {
 	setting         receiver.CreateSettings
@@ -126,6 +151,20 @@ func (kr *k8sobjectsreceiver) startPull(ctx context.Context, config *K8sObjectsC
 				kr.setting.Logger.Error("error in pulling object", zap.String("resource", config.gvr.String()), zap.Error(err))
 			} else if len(objects.Items) > 0 {
 				logs := pullObjectsToLogData(objects, config)
+
+				{
+					// Fence modifications in a nested block for ease of rebasing
+					for _, item := range objects.Items {
+						object := item
+						moreLogs, err1 := kr.ensureReferencesAreKnown(ctx, resource, &object)
+						if err1 != nil {
+							kr.setting.Logger.Error("Cannot retrieve resource versions and owner references", zap.Any("object", toObjectReference(&object)), zap.Error(err))
+						} else if moreLogs != nil && moreLogs.LogRecordCount() > 0 {
+							moreLogs.ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
+						}
+					}
+				}
+
 				obsCtx := kr.obsrecv.StartLogsOp(ctx)
 				err = kr.consumer.ConsumeLogs(obsCtx, logs)
 				kr.obsrecv.EndLogsOp(obsCtx, typeStr, logs.LogRecordCount(), err)
@@ -164,6 +203,17 @@ func (kr *k8sobjectsreceiver) startWatch(ctx context.Context, config *K8sObjects
 			}
 			logs := watchObjectsToLogData(&data, config)
 
+			{
+				// Fence modifications in a nested block for ease of rebasing
+				object := (data.Object).(*unstructured.Unstructured)
+				moreLogs, err := kr.ensureReferencesAreKnown(ctx, resource, object)
+				if err != nil {
+					kr.setting.Logger.Error("Cannot retrieve resource versions and owner references", zap.Any("object", toObjectReference(object)), zap.Error(err))
+				} else if moreLogs != nil && moreLogs.LogRecordCount() > 0 {
+					moreLogs.ResourceLogs().MoveAndAppendTo(logs.ResourceLogs())
+				}
+			}
+
 			obsCtx := kr.obsrecv.StartLogsOp(ctx)
 			err := kr.consumer.ConsumeLogs(obsCtx, logs)
 			kr.obsrecv.EndLogsOp(obsCtx, typeStr, 1, err)
@@ -189,4 +239,203 @@ func NewTicker(repeat time.Duration) *time.Ticker {
 	}()
 	ticker.C = nc
 	return ticker
+}
+
+func (kr *k8sobjectsreceiver) ensureReferencesAreKnown(ctx context.Context, resource dynamic.ResourceInterface, unstructured *unstructured.Unstructured) (*plog.Logs, error) {
+	gvk := unstructured.GroupVersionKind()
+
+	switch gvk {
+	case podv1:
+		{
+			var pod corev1.Pod
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &pod); err != nil {
+				return nil, fmt.Errorf("cannot parse v1.Pod from unstructured: %w", err)
+			}
+
+			kr.addCacheEntry(pod.APIVersion, pod.Kind, string(pod.ObjectMeta.UID), pod.ObjectMeta.ResourceVersion)
+
+			return kr.ensureOwnerReferencesAreKnown(ctx, resource, &pod.ObjectMeta.OwnerReferences)
+		}
+	case eventv1:
+		{
+			// If the object is an event, we look at its involvedObjects instead
+			var event corev1.Event
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &event); err != nil {
+				return nil, fmt.Errorf("cannot parse v1.Event from unstructured: %w", err)
+			}
+			// We do not need to create cache keys for the event itself
+			return kr.ensureObjectReferenceIsKnown(ctx, resource, &event.InvolvedObject)
+		}
+	case daemonsetv1:
+		{
+			var daemonSet appsv1.DaemonSet
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &daemonSet); err != nil {
+				return nil, fmt.Errorf("cannot parse appsv1.DaemonSet from unstructured: %w", err)
+			}
+
+			kr.addCacheEntry(daemonSet.APIVersion, daemonSet.Kind, string(daemonSet.ObjectMeta.UID), daemonSet.ObjectMeta.ResourceVersion)
+
+			return kr.ensureOwnerReferencesAreKnown(ctx, resource, &daemonSet.ObjectMeta.OwnerReferences)
+		}
+	case deploymentv1:
+		{
+			var deployment appsv1.Deployment
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &deployment); err != nil {
+				return nil, fmt.Errorf("cannot parse appsv1.Deployment from unstructured: %w", err)
+			}
+
+			kr.addCacheEntry(deployment.APIVersion, deployment.Kind, string(deployment.ObjectMeta.UID), deployment.ObjectMeta.ResourceVersion)
+
+			return kr.ensureOwnerReferencesAreKnown(ctx, resource, &deployment.ObjectMeta.OwnerReferences)
+		}
+	case replicasetv1:
+		{
+			var replicaSet appsv1.ReplicaSet
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &replicaSet); err != nil {
+				return nil, fmt.Errorf("cannot parse appsv1.ReplicaSet from unstructured: %w", err)
+			}
+
+			kr.addCacheEntry(replicaSet.APIVersion, replicaSet.Kind, string(replicaSet.ObjectMeta.UID), replicaSet.ObjectMeta.ResourceVersion)
+
+			return kr.ensureOwnerReferencesAreKnown(ctx, resource, &replicaSet.ObjectMeta.OwnerReferences)
+		}
+	case statefulsetv1:
+		{
+			var statefulSet appsv1.StatefulSet
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &statefulSet); err != nil {
+				return nil, fmt.Errorf("cannot parse appsv1.StatefulSet from unstructured: %w", err)
+			}
+
+			kr.addCacheEntry(statefulSet.APIVersion, statefulSet.Kind, string(statefulSet.ObjectMeta.UID), statefulSet.ObjectMeta.ResourceVersion)
+
+			return kr.ensureOwnerReferencesAreKnown(ctx, resource, &statefulSet.ObjectMeta.OwnerReferences)
+		}
+	case cronjobv1:
+		{
+			var cronJob batchv1.CronJob
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &cronJob); err != nil {
+				return nil, fmt.Errorf("cannot parse batchv1.CronJob from unstructured: %w", err)
+			}
+
+			kr.addCacheEntry(cronJob.APIVersion, cronJob.Kind, string(cronJob.ObjectMeta.UID), cronJob.ObjectMeta.ResourceVersion)
+
+			return kr.ensureOwnerReferencesAreKnown(ctx, resource, &cronJob.ObjectMeta.OwnerReferences)
+		}
+	case jobv1:
+		{
+			var job batchv1.Job
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &job); err != nil {
+				return nil, fmt.Errorf("cannot parse batchv1.Job from unstructured: %w", err)
+			}
+
+			kr.addCacheEntry(job.APIVersion, job.Kind, string(job.ObjectMeta.UID), job.ObjectMeta.ResourceVersion)
+
+			return kr.ensureOwnerReferencesAreKnown(ctx, resource, &job.ObjectMeta.OwnerReferences)
+		}
+	default:
+		return nil, fmt.Errorf("unexpected GroupVersionKind: %+v", gvk)
+	}
+}
+
+func (kr *k8sobjectsreceiver) ensureOwnerReferencesAreKnown(ctx context.Context, resource dynamic.ResourceInterface, ownerReferences *[]metav1.OwnerReference) (*plog.Logs, error) {
+	res := plog.NewLogs()
+	for _, ownerReference := range *ownerReferences {
+		objectReference := corev1.ObjectReference{
+			Kind:       ownerReference.Kind,
+			Name:       ownerReference.Name,
+			APIVersion: ownerReference.APIVersion,
+			UID:        ownerReference.UID,
+		}
+
+		logs, err := kr.ensureObjectReferenceIsKnown(ctx, resource, &objectReference)
+		if err != nil {
+			return nil, fmt.Errorf("cannot retrieve owner reference '%v': %w", objectReference, err)
+		}
+
+		if logs != nil {
+			logs.CopyTo(res)
+		}
+	}
+
+	return &res, nil
+}
+
+func (kr *k8sobjectsreceiver) ensureObjectReferenceIsKnown(ctx context.Context, resource dynamic.ResourceInterface, objectRef *corev1.ObjectReference) (*plog.Logs, error) {
+	if kr.hasCacheEntry(objectRef.APIVersion, objectRef.Kind, string(objectRef.UID), objectRef.ResourceVersion) {
+		return nil, nil
+	}
+
+	kr.setting.Logger.Debug("Retrieving object reference", zap.Any("objectReference", objectRef))
+
+	listOptions := metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: objectRef.APIVersion,
+			Kind:       objectRef.Kind,
+		},
+	}
+
+	// We might not have a resource version, if this object reference is created from an owner reference
+	if objectRef.ResourceVersion != "" {
+		listOptions.ResourceVersion = objectRef.ResourceVersion
+		listOptions.ResourceVersionMatch = metav1.ResourceVersionMatchExact
+	}
+
+	res, err := resource.List(ctx, listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list %s/%s for resource version '%s': %w", objectRef.APIVersion, objectRef.Kind, objectRef.ResourceVersion, err)
+	}
+
+	cfg := K8sObjectsConfig{
+		gvr: &schema.GroupVersionResource{
+			Version:  objectRef.APIVersion,
+			Resource: strings.ToLower(objectRef.Kind),
+		},
+	}
+
+	logs := unstructuredListToLogData(res, &cfg)
+
+	kr.addCacheEntry(objectRef.APIVersion, objectRef.Kind, string(objectRef.UID), objectRef.ResourceVersion)
+
+	return &logs, nil
+}
+
+func (kr *k8sobjectsreceiver) hasCacheEntry(apiVersion, kind, uid, resourceVersion string) bool {
+	return cache.Contains(toCacheKey(apiVersion, kind, uid, resourceVersion))
+}
+
+func (kr *k8sobjectsreceiver) addCacheEntry(apiVersion, kind, uid, resourceVersion string) {
+	cacheKey := toCacheKey(apiVersion, kind, uid, resourceVersion)
+
+	if cache.Contains(cacheKey) {
+		return
+	}
+
+	cache.Add(cacheKey, true)
+
+	kr.setting.Logger.Debug("Added cache key", zap.Any("cacheKey", cacheKey))
+
+	if resourceVersion != "" {
+		// Also add entry independent from resource version for owner references
+		objectCacheKey := toCacheKey(apiVersion, kind, uid, "")
+
+		if !cache.Contains(objectCacheKey) {
+			cache.Add(objectCacheKey, true)
+			kr.setting.Logger.Debug("Added cache key", zap.Any("cacheKey", objectCacheKey))
+		}
+	}
+}
+
+func toCacheKey(apiVersion, kind, uid, resourceVersion string) string {
+	return fmt.Sprintf("%s.%s/%s@%s", apiVersion, kind, uid, resourceVersion)
+}
+
+func toObjectReference(obj *unstructured.Unstructured) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		APIVersion:      obj.GetAPIVersion(),
+		Kind:            obj.GetKind(),
+		Namespace:       obj.GetNamespace(),
+		Name:            obj.GetName(),
+		UID:             obj.GetUID(),
+		ResourceVersion: obj.GetResourceVersion(),
+	}
 }

--- a/receiver/k8sobjectsreceiver/receiver_references_test.go
+++ b/receiver/k8sobjectsreceiver/receiver_references_test.go
@@ -1,0 +1,176 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sobjectsreceiver
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestReferences(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Receiver References tests")
+}
+
+var _ = Context("Lumigo controller", func() {
+
+	It("Send all needed Pod references", func() {
+		mockClient := newMockDynamicClient()
+
+		rCfg := createDefaultConfig().(*Config)
+		rCfg.makeDynamicClient = mockClient.getMockDynamicClient
+		rCfg.makeDiscoveryClient = getMockDiscoveryClient
+
+		rCfg.Objects = []*K8sObjectsConfig{
+			{
+				Name:       "pods",
+				Mode:       WatchMode,
+				Namespaces: []string{"default"},
+			},
+			{
+				Name:       "events",
+				Mode:       WatchMode,
+				Namespaces: []string{"default"},
+			},
+		}
+
+		err := rCfg.Validate()
+		Expect(err).NotTo(HaveOccurred())
+
+		consumer := newMockLogConsumer()
+		r, err := newReceiver(
+			receivertest.NewNopCreateSettings(),
+			rCfg,
+			consumer,
+		)
+		Expect(r).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx := context.Background()
+		Expect(r.Start(ctx, componenttest.NewNopHost())).NotTo(HaveOccurred())
+
+		time.Sleep(time.Millisecond * 100)
+
+		pod1 := generatePod("pod1", "default", map[string]interface{}{
+			"environment": "production",
+		}, "1234")
+		pod2 := generatePod("pod2", "default", map[string]interface{}{
+			"environment": "test",
+		}, "5678")
+		pod3 := generatePod("pod3", "default_ignore", map[string]interface{}{
+			"environment": "production",
+		}, "9012")
+		mockClient.createPods(pod1, pod2, pod3)
+		time.Sleep(time.Second * 1)
+
+		// The pods mentioned by the events below have all been reported yet.
+		// We expect only one log per event.
+		mockClient.createEvents(
+			generateEvent("event1", "default", map[string]interface{}{
+				"environment": "production",
+			}, pod1),
+			generateEvent("event2", "default", map[string]interface{}{
+				"environment": "production",
+			}, pod2),
+		)
+
+		time.Sleep(time.Second * 1)
+
+		Eventually(func(g Gomega) {
+			logRecords := getLogRecords(consumer.Logs())
+
+			g.Expect(logRecords).Should(ContainElement(matchWatchEvent(watch.Added, toObjectReference(pod1))))
+			g.Expect(logRecords).Should(ContainElement(matchWatchEvent(watch.Added, toObjectReference(pod2))))
+		}, 1*time.Minute, 1*time.Second).Should(Succeed())
+
+		// TODO Improve tests using a deployment and check that all needed resourceVersions of pods and replicasets
+		// are fetched
+	})
+})
+
+func getLogRecords(logs []plog.Logs) []plog.LogRecord {
+	logRecords := make([]plog.LogRecord, 0)
+
+	for g := 0; g < len(logs); g++ {
+		for i := 0; i < logs[g].ResourceLogs().Len(); i++ {
+			resourceLogs := logs[g].ResourceLogs().At(i)
+			for j := 0; j < resourceLogs.ScopeLogs().Len(); j++ {
+				scopeLogs := resourceLogs.ScopeLogs().At(j)
+				for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
+					logRecords = append(logRecords, scopeLogs.LogRecords().At(k))
+				}
+			}
+		}
+	}
+
+	return logRecords
+}
+
+func matchWatchEvent(eventType watch.EventType, objectReference *corev1.ObjectReference) WatchEventMatcher {
+	return WatchEventMatcher{
+		ExpectedEventType:       eventType,
+		ExpectedObjectReference: objectReference,
+	}
+}
+
+type WatchEventMatcher struct {
+	ExpectedEventType       watch.EventType
+	ExpectedObjectReference *corev1.ObjectReference
+}
+
+func (wem WatchEventMatcher) Match(actual interface{}) (success bool, err error) {
+	logRecord := actual.(plog.LogRecord)
+
+	eventRaw := logRecord.Body().AsRaw().(map[string]interface{})
+	eventType := eventRaw["type"]
+
+	if eventType != string(wem.ExpectedEventType) {
+		return false, fmt.Errorf("mismatching event type: expected '%s'; received '%s", wem.ExpectedEventType, eventType)
+	}
+
+	eventObject := unstructured.Unstructured{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(eventRaw["object"].(map[string]interface{}), &eventObject); err != nil {
+		return false, err
+	}
+
+	actualObjectReference := toObjectReference(&eventObject)
+	if reflect.DeepEqual(actualObjectReference, wem.ExpectedObjectReference) {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("mismatching object reference type: expected '%v'; received '%v", wem.ExpectedObjectReference, actualObjectReference)
+}
+
+func (wem WatchEventMatcher) FailureMessage(actual interface{}) (message string) {
+	return "Actual does not match expected watch.Event"
+}
+
+func (wem WatchEventMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return "Actual matches watch.Event"
+}

--- a/receiver/k8sobjectsreceiver/receiver_test.go
+++ b/receiver/k8sobjectsreceiver/receiver_test.go
@@ -50,13 +50,13 @@ func TestPullObject(t *testing.T) {
 	mockClient.createPods(
 		generatePod("pod1", "default", map[string]interface{}{
 			"environment": "production",
-		}),
+		}, "1234"),
 		generatePod("pod2", "default", map[string]interface{}{
 			"environment": "test",
-		}),
+		}, "5678"),
 		generatePod("pod3", "default_ignore", map[string]interface{}{
 			"environment": "production",
-		}),
+		}, "9012"),
 	)
 
 	rCfg := createDefaultConfig().(*Config)
@@ -127,13 +127,13 @@ func TestWatchObject(t *testing.T) {
 	mockClient.createPods(
 		generatePod("pod1", "default", map[string]interface{}{
 			"environment": "production",
-		}),
+		}, "1234"),
 		generatePod("pod2", "default", map[string]interface{}{
 			"environment": "test",
-		}),
+		}, "5678"),
 		generatePod("pod3", "default_ignore", map[string]interface{}{
 			"environment": "production",
-		}),
+		}, "9012"),
 	)
 	time.Sleep(time.Millisecond * 100)
 	assert.Len(t, consumer.Logs(), 2)
@@ -142,7 +142,7 @@ func TestWatchObject(t *testing.T) {
 	mockClient.createPods(
 		generatePod("pod4", "default", map[string]interface{}{
 			"environment": "production",
-		}),
+		}, "3456"),
 	)
 	time.Sleep(time.Millisecond * 100)
 	assert.Len(t, consumer.Logs(), 3)


### PR DESCRIPTION
Description: Patched the `k8sobjectsreceiver` to make it try to collect and send downstream all `resourceVersion`s of objects it sees referenced in events, and to ensure that the latest `resourceVersion` of objects referenced by `ownerReference`s are sent downstream ASAP on startup.